### PR TITLE
Fixed rule 'Useless parentheses around expressions should be removed …

### DIFF
--- a/src/main/java/org/jboss/forge/plugin/idea/context/UIContextFactory.java
+++ b/src/main/java/org/jboss/forge/plugin/idea/context/UIContextFactory.java
@@ -53,7 +53,7 @@ public class UIContextFactory
          List<Resource> resources = filesToResources(files);
          if (editor != null)
          {
-            selection = Selections.from((resource) -> {
+            selection = Selections.from(resource -> {
                Document document = editor.getDocument();
                SelectionModel selectionModel = editor.getSelectionModel();
                return new UIRegionImpl(resource, document, selectionModel);

--- a/src/main/java/org/jboss/forge/plugin/idea/runtime/UIPromptImpl.java
+++ b/src/main/java/org/jboss/forge/plugin/idea/runtime/UIPromptImpl.java
@@ -23,9 +23,7 @@ public class UIPromptImpl implements UIPrompt
    @Override
    public String prompt(final String message)
    {
-      ApplicationManager.getApplication().invokeAndWait(() -> {
-         stringValue = Messages.showInputDialog("", message, Messages.getQuestionIcon());
-      } , ModalityState.any());
+      ApplicationManager.getApplication().invokeAndWait(() -> stringValue = Messages.showInputDialog("", message, Messages.getQuestionIcon()), ModalityState.any());
       return stringValue;
    }
 
@@ -39,9 +37,7 @@ public class UIPromptImpl implements UIPrompt
    @Override
    public boolean promptBoolean(final String message)
    {
-      ApplicationManager.getApplication().invokeAndWait(() -> {
-         booleanValue = Messages.showYesNoDialog(message, "", Messages.getQuestionIcon()) == Messages.YES;
-      } , ModalityState.any());
+      ApplicationManager.getApplication().invokeAndWait(() -> booleanValue = Messages.showYesNoDialog(message, "", Messages.getQuestionIcon()) == Messages.YES, ModalityState.any());
       return booleanValue;
 
    }

--- a/src/main/java/org/jboss/forge/plugin/idea/ui/CommandListPopupBuilder.java
+++ b/src/main/java/org/jboss/forge/plugin/idea/ui/CommandListPopupBuilder.java
@@ -96,9 +96,8 @@ public class CommandListPopupBuilder
       Map<Object, String> filterIndex = indexFilterData(elements, categories, metadataIndex);
 
       JBList list = buildJBList(elements, metadataIndex);
-      JBPopup popup = buildPopup(list, filterIndex);
 
-      return popup;
+      return buildPopup(list, filterIndex);
    }
 
    @SuppressWarnings("unchecked")

--- a/src/main/java/org/jboss/forge/plugin/idea/ui/component/CheckboxComponentBuilder.java
+++ b/src/main/java/org/jboss/forge/plugin/idea/ui/component/CheckboxComponentBuilder.java
@@ -42,8 +42,8 @@ public class CheckboxComponentBuilder extends ComponentBuilder
          public void buildUI(Container container)
          {
             // Create the label
-            String text = (input.getLabel() == null ? input.getName() : input
-                     .getLabel());
+            String text = input.getLabel() == null ? input.getName() : input
+                     .getLabel();
             checkbox = new JCheckBox(text);
 
             checkbox.addActionListener(new ActionListener()
@@ -84,7 +84,7 @@ public class CheckboxComponentBuilder extends ComponentBuilder
          private boolean getInputValue()
          {
             Object value = InputComponents.getValueFor(input);
-            return (value != null && converter.convert(value));
+            return value != null && converter.convert(value);
          }
       };
    }

--- a/src/main/java/org/jboss/forge/plugin/idea/ui/wizard/ForgeWizardDialog.java
+++ b/src/main/java/org/jboss/forge/plugin/idea/ui/wizard/ForgeWizardDialog.java
@@ -37,12 +37,6 @@ public class ForgeWizardDialog extends WizardDialog<ForgeWizardModel>
         refreshTitle();
     }
 
-    @Override
-    public String getTitle()
-    {
-        return super.getTitle();
-    }
-
     public void refreshTitle()
     {
         Object selection = context.getSelection().get();


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules:
squid:UselessParenthesesCheck - Useless parentheses around expressions should be removed to prevent any misunderstanding;
squid:S1602 - Lamdbas containing only one statement should not nest this statement in a block;
squid:S1185 - Overriding methods should do more than simply call the same method in the super class;
squad:S1488 - Local Variables should not be declared and then immediately returned or thrown;

You can find more information about the issues here:
https://dev.eclipse.org/sonar/rules/show/squid:UselessParenthesesCheck
https://dev.eclipse.org/sonar/rules/show/squid:S1602 
https://dev.eclipse.org/sonar/rules/show/squid:S1185 
https://dev.eclipse.org/sonar/rules/show/squad:S1488 

Please let me know if you have any questions.
Soso Tughushi


