### PR TITLE
squid:S1118 - Utility classes should not have public constructors

### DIFF
--- a/src/main/java/org/jboss/forge/plugin/idea/context/UIContextFactory.java
+++ b/src/main/java/org/jboss/forge/plugin/idea/context/UIContextFactory.java
@@ -34,6 +34,8 @@ import com.intellij.openapi.vfs.VirtualFile;
 @SuppressWarnings("rawtypes")
 public class UIContextFactory
 {
+   private UIContextFactory(){}
+
    public static UIContext create(Project project, Editor editor, VirtualFile[] files)
    {
       UIProvider provider = new UIProviderImpl();

--- a/src/main/java/org/jboss/forge/plugin/idea/util/CommandUtil.java
+++ b/src/main/java/org/jboss/forge/plugin/idea/util/CommandUtil.java
@@ -30,6 +30,8 @@ import org.jboss.forge.plugin.idea.service.ForgeService;
  */
 public class CommandUtil
 {
+    private CommandUtil(){}
+
     private static final String RECENT_COMMANDS = "Recent Commands";
 
     public static List<UICommand> getAllCommands()

--- a/src/main/java/org/jboss/forge/plugin/idea/util/CompletionUtil.java
+++ b/src/main/java/org/jboss/forge/plugin/idea/util/CompletionUtil.java
@@ -25,6 +25,8 @@ import com.intellij.ui.TextFieldWithAutoCompletion;
 @SuppressWarnings("unchecked")
 public class CompletionUtil
 {
+   private CompletionUtil(){}
+
    public static boolean hasCompletions(InputComponent<?, Object> input)
    {
       return input instanceof HasCompleter && ((HasCompleter<?, Object>) input).getCompleter() != null;

--- a/src/main/java/org/jboss/forge/plugin/idea/util/ForgeNotifications.java
+++ b/src/main/java/org/jboss/forge/plugin/idea/util/ForgeNotifications.java
@@ -21,6 +21,8 @@ import com.intellij.openapi.ui.MessageType;
  */
 public class ForgeNotifications
 {
+   private ForgeNotifications(){}
+   
    private static final NotificationGroup NOTIFICATION_GROUP = NotificationGroup.balloonGroup("Forge Notifications");
 
    private static final String SUCCESS_MESSAGE = "Command executed successfully";

--- a/src/main/java/org/jboss/forge/plugin/idea/util/IDEUtil.java
+++ b/src/main/java/org/jboss/forge/plugin/idea/util/IDEUtil.java
@@ -37,6 +37,8 @@ import com.intellij.psi.util.ClassUtil;
  */
 public class IDEUtil
 {
+   private IDEUtil(){}
+   
    public static void refreshProject(UIContext context)
    {
       Project project = projectFromContext(context);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule:
squid:S1118 - Utility classes should not have public constructors;

You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1118

Please let me know if you have any questions.
Soso Tughushi